### PR TITLE
Add support multiple input types

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,15 @@
+package cmd
+
+const (
+	DECODE_COMMAND = "decode"
+	ENCODE_COMMAND = "encode"
+)
+
+const (
+	FILE_FLAG     = "file"
+	PASSWORD_FLAG = "password"
+	PATH_FLAG     = "path"
+	SECRET_FLAG   = "secret"
+	STDIN_FLAG    = "stdin"
+	TEXT_FLAG     = "text"
+)

--- a/cmd/decode.go
+++ b/cmd/decode.go
@@ -48,5 +48,5 @@ var decodeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(decodeCmd)
-	decodeCmd.Flags().String("path", "", "Path of file")
+	decodeCmd.Flags().String(PATH_FLAG, "", "Path of file")
 }

--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -5,7 +5,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"strconv"
 	"time"
@@ -22,28 +22,83 @@ var encodeCmd = &cobra.Command{
 	Short: "Encode the hidden text in a normal text using password.",
 	Long:  `Encode the hidden text in a normal text using password.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		password, err := cmd.Flags().GetString(PASSWORD_FLAG)
+		fatalOnErr(err)
+		hiddenText, err := cmd.Flags().GetString(SECRET_FLAG)
+		fatalOnErr(err)
 
-		coverText, _ := cmd.Flags().GetString("text")
-		hiddenText, _ := cmd.Flags().GetString("secret")
-		password, _ := cmd.Flags().GetString("password")
-
-		if coverText != "" && hiddenText != "" && password != "" {
-			now := time.Now()
-			cipherSecret, _ := utils.Encrypt(hiddenText, password)
-			encodedText := src.Encode(coverText, []byte(cipherSecret))
-			color.Green.Println("Your text was added to file and you can share it with anyone!")
-			err := os.WriteFile(strconv.Itoa(int(time.Now().Unix()))+".txt", []byte(encodedText), 0777)
-			if err != nil {
-				log.Fatal(err)
-			}
-			color.Cyan.Println("File written successfully!")
-			fmt.Print("Finished in: ")
-			color.BgHiGreen.Println(time.Since(now))
+		if password == "" || hiddenText == "" {
+			color.Red.Printf("%q and %q flags cannot be empty for %q sub-command!\n", SECRET_FLAG, PASSWORD_FLAG, ENCODE_COMMAND)
+			os.Exit(1)
 		}
+		var text string
+		var r io.Reader
+		var providedInputFlags uint
+
+		coverText, err := cmd.Flags().GetString(TEXT_FLAG)
+		fatalOnErr(err)
+		if coverText != "" {
+			providedInputFlags++
+		}
+
+		stdin, err := cmd.Flags().GetBool(STDIN_FLAG)
+		fatalOnErr(err)
+		if stdin {
+			providedInputFlags++
+		}
+
+		file, err := cmd.Flags().GetString(FILE_FLAG)
+		fatalOnErr(err)
+		if file != "" {
+			providedInputFlags++
+		}
+
+		if providedInputFlags != 1 {
+			color.Red.Printf("one input flag is required, please provide just one of: %q, %q, or %q\n", TEXT_FLAG, STDIN_FLAG, FILE_FLAG)
+			os.Exit(1)
+		}
+
+		var needFileRead bool
+		if coverText != "" {
+			text = coverText
+		} else if stdin {
+			r = os.Stdin
+			needFileRead = true
+		} else if file != "" {
+			f, err := os.Open(file)
+			if err != nil {
+				color.Red.Printf("error opening file %q: %s\n", file, err.Error())
+				os.Exit(1)
+			}
+			defer f.Close()
+
+			r = f
+			needFileRead = true
+		}
+
+		if needFileRead {
+			data, err := io.ReadAll(r)
+			fatalOnErr(err)
+			text = string(data)
+		}
+
+		now := time.Now()
+		cipherSecret, _ := utils.Encrypt(hiddenText, password)
+		encodedText := src.Encode(text, []byte(cipherSecret))
+		color.Green.Println("Your text was added to file and you can share it with anyone!")
+		err = os.WriteFile(strconv.Itoa(int(now.Unix()))+".txt", []byte(encodedText), 0777)
+		fatalOnErr(err)
+		color.Cyan.Println("File written successfully!")
+		fmt.Print("Finished in: ")
+		color.BgHiGreen.Println(time.Since(now))
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(encodeCmd)
-	encodeCmd.Flags().String("secret", "", "A secret to be hidden!")
+	encodeCmd.Flags().String(SECRET_FLAG, "", "A secret to be hidden!")
+
+	encodeCmd.Flags().String(FILE_FLAG, "", "Path to file containing the input text")
+	encodeCmd.Flags().Bool(STDIN_FLAG, false, "Input text from stdin")
+	encodeCmd.Flags().String(TEXT_FLAG, "", "An encoded text to extract secret from it!")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ Copyright © 2024 NAME HERE <AAVISION>
 package cmd
 
 import (
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -19,12 +20,6 @@ The hidden secret text is protected by a password.`,
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
-
-var (
-	// Global flag variable
-	text     string
-	password string
-)
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -44,7 +39,11 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.PersistentFlags().StringVar(&text, "text", "", "An encoded text to extract secret from it!")
-	rootCmd.PersistentFlags().StringVar(&password, "password", "", "A password to protect your text!")
+	rootCmd.PersistentFlags().String(PASSWORD_FLAG, "", "A password to protect your text!")
+}
 
+func fatalOnErr(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
in the current implementation, the user can just add the input using the "--text" flag, this is good, but somehow limited, especially if this tool is gonna be used in automation scripts, it would be much better to support providing the input through `stdin` or by providing a path to a file.
in this PR I've addressed this issue.